### PR TITLE
Deprecate built-in linkTo/action addons

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,1 +1,2 @@
-require('@kadira/storybook/addons');
+import '@kadira/storybook-addon-actions/register';
+import '@kadira/storybook-addon-links/register';

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   },
   "devDependencies": {
     "@kadira/storybook": "^2.35.3",
+    "@kadira/storybook-addon-actions": "^1.1.3",
+    "@kadira/storybook-addon-links": "^1.0.1",
+    "@kadira/storybook-addons": "^1.6.1",
     "gh-pages": "^0.12.0"
   },
   "keywords": [

--- a/pages/docs/react-storybook/addons/introduction/index.md
+++ b/pages/docs/react-storybook/addons/introduction/index.md
@@ -58,9 +58,9 @@ storiesOf('Button', module)
 You can also add a decorator globally for all stories like this:
 
 ~~~js
-import {
-    storiesOf, action, addDecorator
-} from '@kadira/storybook';
+import { storiesOf, addDecorator } from '@kadira/storybook';
+import { action } from '@kadira/storybook-addon-actions';
+import { linkTo } from '@kadira/storybook-addon-links';
 
 const CenterDecorator = (story) => (
   <div style={{ textAlign: "center" }}>

--- a/pages/docs/react-storybook/addons/using-addons/index.md
+++ b/pages/docs/react-storybook/addons/using-addons/index.md
@@ -27,7 +27,8 @@ npm i --save '@kadira/storybook-addon-notes';
 After that, add it to the addons.js like this:
 
 ~~~js
-import '@kadira/storybook/addons';
+import '@kadira/storybook-addon-actions/register';
+import '@kadira/storybook-addon-links/register';
 import '@kadira/storybook-addon-notes/register';
 ~~~
 
@@ -40,7 +41,9 @@ Now when you are writing a story it like this and add some notes:
 
 ~~~js
 import React from 'react';
-import { storiesOf, action, linkTo } from '@kadira/storybook';
+import { storiesOf } from '@kadira/storybook';
+import { action } from '@kadira/storybook-addon-actions';
+import { linkTo } from '@kadira/storybook-addon-links';
 import Button from './Button';
 import { WithNotes } from '@kadira/storybook-addon-notes';
 

--- a/pages/docs/react-storybook/addons/writing-addons/index.md
+++ b/pages/docs/react-storybook/addons/writing-addons/index.md
@@ -42,7 +42,8 @@ We write a story for our addon like this:
 
 ~~~js
 import React from 'react';
-import { storiesOf, action } from '@kadira/storybook';
+import { storiesOf } from '@kadira/storybook';
+import { action } from '@kadira/storybook-addon-actions';
 import Button from './Button';
 import { WithNotes } from '../notes-addon';
 
@@ -68,8 +69,8 @@ Then it will appear in the Notes panel like this:
 First, create an `addons.js` inside the Storybook config directory and add the following content to it.
 
 ~~~js
-// Storybook's default addons
-import '@kadira/storybook/addons';
+// Register the actions addon that we used above
+import '@kadira/storybook-addon-actions/register';
 ~~~
 
 We'll use this file shortly to register the Notes addon we are building.
@@ -118,8 +119,8 @@ It also listens to another event, called onStory, in the storybook API, which fi
 Now, finally, we need to register the addon by importing it to the `.storybook/addons.js` file.
 
 ~~~js
-// Storybook's default addons
-import '@kadira/storybook/addons';
+// Register the actions addon that we used above
+import '@kadira/storybook-addon-actions/register';
 
 // Our addon
 import '../src/notes-addon/register';
@@ -132,7 +133,8 @@ That's it. Now you can create notes for any story as shown below:
 
 ~~~js
 import React from 'react';
-import { storiesOf, action } from '@kadira/storybook';
+import { storiesOf } from '@kadira/storybook';
+import { action } from '@kadira/storybook-addon-actions';
 import Button from './Button';
 import { WithNotes } from '../notes-addon';
 


### PR DESCRIPTION
Issue: https://github.com/storybooks/storybook/issues/1017

## What I did

Update the docs so that all examples are consistent with the new package structure. Still need to add migration instructions with the 3.0 release.