### PR TITLE
update storybook-router description

### DIFF
--- a/pages/docs/react-storybook/addons/addon-gallery/index.md
+++ b/pages/docs/react-storybook/addons/addon-gallery/index.md
@@ -75,7 +75,7 @@ Given possible values for each prop, renders your component with all combination
 
 ### [StoryRouter](https://github.com/gvaldambrini/storybook-router)
 
-A [decorator](/docs/react-storybook/addons/introduction) that allows you to integrate react-router v.4 components in your stories.
+A [decorator](/docs/react-storybook/addons/introduction) that allows you to integrate react-router components in your stories.
 
 ### [JSX preview](https://github.com/Kilix/storybook-addon-jsx)
 


### PR DESCRIPTION
As storybook-router now supports react-router v3 remove the version from the description.
