### PR TITLE
Fix formatting issue on cli-options page

### DIFF
--- a/pages/docs/react-storybook/configurations/cli-options/index.md
+++ b/pages/docs/react-storybook/configurations/cli-options/index.md
@@ -11,7 +11,7 @@ Here are all those options:
 
 ## For start-storybook
 
-```log
+```
 Usage: start-storybook [options]
 
 Options:
@@ -26,7 +26,7 @@ Options:
 
 ## For build-storybook
 
-```log
+```
 Usage: build-storybook [options]
 
 Options:


### PR DESCRIPTION
Issue: N/A

## What I did

Fix formatting issue introduced in https://github.com/storybooks/storybooks.github.io/pull/24

Before:

<img width="614" alt="cli_options_-_react_storybook" src="https://cloud.githubusercontent.com/assets/488689/26112259/c8e84bd6-3a9a-11e7-8c98-3317e0955d75.png">

After:

<img width="728" alt="cli_options_-_react_storybook" src="https://cloud.githubusercontent.com/assets/488689/26112225/acc36c10-3a9a-11e7-9581-8419879f6c75.png">


