### PR TITLE
Site redirect: hack in global `window` for Gatsby server-side page generation for 

### DIFF
--- a/pages/_template.jsx
+++ b/pages/_template.jsx
@@ -6,6 +6,11 @@ import { colors, activeColors } from 'utils/colors';
 import { rhythm, adjustFontSizeTo } from 'utils/typography';
 import { config } from 'config';
 
+let { window } = global;
+if (!window) {
+  window = { location: { href: '' } };
+}
+
 const PREFIX = 'https://storybook.js.org';
 const redirectHref = ({ protocol, host, href }) => {
   const match = href.match(/\/docs\/react-storybook(.*)$/);


### PR DESCRIPTION
Issue: #63 

## What I did

This is a temporary fix for #63. The deployment failed because `window`
is not defined on the server. There are certainly more elegant fixes,
but this is quick and the site is deprecated.

## How to test
```
yarn build
cd public
python -m SimpleHTTPServer
open http://localhost:8000
```
