### PR TITLE
Fix capitalisation in algolia example

### DIFF
--- a/pages/examples/_examples.yml
+++ b/pages/examples/_examples.yml
@@ -21,7 +21,7 @@ lonelyplanet:
   site: https://www.lonelyplanet.com/
 algolia:
   thumbnail: ./thumbnails/algolia.jpg
-  title: Algolia Instantsearch
+  title: Algolia InstantSearch
   description: Lightning-fast, hyper-configurable search.
   source: https://github.com/algolia/react-instantsearch/
   demo: https://community.algolia.com/react-instantsearch/storybook/


### PR DESCRIPTION
Hey, thanks for the mention! according to our brand guidelines, InstantSearch is with two capital letters though, so this pr fixed that

Cc @vvo

Issue:

## What I did
